### PR TITLE
fix load string from txt for Windows OS

### DIFF
--- a/test.js
+++ b/test.js
@@ -28,7 +28,7 @@ if (search) {
 } else {
   const searches = fs.readFileSync('search.txt').toString().split("\n");
   for(let i in testSuite) {
-    testSuite[i].search = searches[i];
+    testSuite[i].search = searches[i].trim();
   }
 }
 let performResults = {}


### PR DESCRIPTION
I am add trim from load string from text files, for crossplatform (show table in terminal Windows OS). Problem with line endings (CR LF > LF)